### PR TITLE
Support Windows and BYOL Build

### DIFF
--- a/.changeset/eighty-apples-raise.md
+++ b/.changeset/eighty-apples-raise.md
@@ -1,0 +1,5 @@
+---
+"smart-whisper": minor
+---
+
+Support BYOL (Bring your own library) for complex libwhisper.a / libwhisper.so usage

--- a/.changeset/three-eggs-invent.md
+++ b/.changeset/three-eggs-invent.md
@@ -1,0 +1,5 @@
+---
+"smart-whisper": minor
+---
+
+Move all build process into gyp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-latest, macos-latest] # windows-latest has a bug with makefile (cc command not found)
+                os: [ubuntu-latest, macos-latest, windows-latest]
                 node: [18, 20]
 
         steps:
@@ -35,9 +35,6 @@ jobs:
               uses: pnpm/action-setup@v2
               with:
                   run_install: true
-
-            - name: Build All
-              run: pnpm makelib && pnpm build
 
             - name: Test
               run: pnpm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,16 +31,6 @@ jobs:
             - name: Install distutils
               run: python -m pip install setuptools
 
-            - uses: Jimver/cuda-toolkit@v0.2.11
-              with:
-                  sub-packages: '["nvcc"]'
-                  method: network
-              if: matrix.os == 'windows-latest'
-
-            - name: Add msys64 to PATH
-              run: echo "/c/msys64/mingw64/bin:/c/msys64/usr/bin" >> $GITHUB_PATH
-              if: matrix.os == 'windows-latest'
-
             - name: Setup PNPM
               uses: pnpm/action-setup@v2
               with:

--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ out
 
 # Nuxt.js build / generate output
 .nuxt
-dist
+
 
 # Gatsby files
 .cache/
@@ -129,3 +129,6 @@ dist
 /whsiper.cpp
 /build
 /docs
+dist/*.js
+dist/*.ts
+!/dist/build.js

--- a/binding.gyp
+++ b/binding.gyp
@@ -15,6 +15,8 @@
       'defines': [ "<!@(node -p \"require('./dist/build.js').defines\")" ],
       'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")", "whisper.cpp", "whisper.cpp/examples"],
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
       'xcode_settings': {
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,12 +9,12 @@
           "src/binding.cc",
           "src/binding/model.cc",
           "src/binding/transcribe.cc",
+          "<!@(node -p \"require('./dist/build.js').sources\")"
       ],
-      "libraries": [ "<(module_root_dir)/whisper.cpp/libwhisper.a", "<!@(node scripts/linker.js)" ],
+      "libraries": [ "<!@(node -p \"require('./dist/build.js').libraries\")" ],
+      'defines': [ "<!@(node -p \"require('./dist/build.js').defines\")" ],
       'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")", "whisper.cpp", "whisper.cpp/examples"],
       'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
-      'cflags!': [ '-fno-exceptions' ],
-      'cflags_cc!': [ '-fno-exceptions' ],
       'xcode_settings': {
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',
@@ -24,15 +24,6 @@
       },
       'conditions': [
         ['OS=="mac"', {
-            'cflags+': ['-fvisibility=hidden'],
-            'link_settings': {
-                'libraries': [
-                    '-framework CoreFoundation',
-                    '-framework Foundation',
-                    '-framework Metal',
-                    '-framework MetalKit',
-                ],
-            },
             'xcode_settings': {
                 'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
             }

--- a/dist/build.js
+++ b/dist/build.js
@@ -1,0 +1,125 @@
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+	for (var name in all) __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+	if ((from && typeof from === "object") || typeof from === "function") {
+		for (let key of __getOwnPropNames(from))
+			if (!__hasOwnProp.call(to, key) && key !== except)
+				__defProp(to, key, {
+					get: () => from[key],
+					enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable,
+				});
+	}
+	return to;
+};
+var __toESM = (mod, isNodeMode, target) => (
+	(target = mod != null ? __create(__getProtoOf(mod)) : {}),
+	__copyProps(
+		// If the importer is in node compatibility mode or this is not an ESM
+		// file that has been converted to a CommonJS file using a Babel-
+		// compatible transform (i.e. "__esModule" has not been set), then set
+		// "default" to the CommonJS "module.exports" for node compatibility.
+		isNodeMode || !mod || !mod.__esModule
+			? __defProp(target, "default", { value: mod, enumerable: true })
+			: target,
+		mod,
+	)
+);
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/build.ts
+var build_exports = {};
+__export(build_exports, {
+	defines: () => defines,
+	libraries: () => libraries,
+	sources: () => sources,
+});
+module.exports = __toCommonJS(build_exports);
+var import_node_os = __toESM(require("os"));
+var cfg = config();
+var sources = cfg.sources.join(" ");
+var defines = cfg.defines.join(" ");
+var libraries = cfg.libraries.join(" ");
+function config() {
+	var _a;
+	if (process.env.BYOL) {
+		return {
+			sources: [],
+			defines: [],
+			libraries: [process.env.BYOL],
+		};
+	}
+	const COMPUTE_BACKEND = (_a = process.env.COMPUTE_BACKEND) != null ? _a : infer_backend();
+	const cfg2 = {
+		sources: [
+			"whisper.cpp/whisper.cpp",
+			"whisper.cpp/ggml.c",
+			"whisper.cpp/ggml-alloc.c",
+			"whisper.cpp/ggml-backend.c",
+			"whisper.cpp/ggml-quants.c",
+		],
+		defines: [],
+		libraries: [],
+	};
+	switch (COMPUTE_BACKEND) {
+		case "accelerate": {
+			cfg2.defines.push("GGML_USE_ACCELERATE");
+			cfg2.libraries.push('"-framework Foundation"');
+			cfg2.libraries.push('"-framework Accelerate"');
+			break;
+		}
+		case "metal": {
+			cfg2.sources.push("whisper.cpp/ggml-metal.m");
+			cfg2.defines.push("GGML_USE_ACCELERATE");
+			cfg2.defines.push("GGML_USE_METAL");
+			cfg2.libraries.push('"-framework Foundation"');
+			cfg2.libraries.push('"-framework Accelerate"');
+			cfg2.libraries.push('"-framework Metal"');
+			cfg2.libraries.push('"-framework MetalKit"');
+			break;
+		}
+		case "openblas": {
+			cfg2.defines.push("GGML_USE_OPENBLAS");
+			cfg2.libraries.push("-lopenblas");
+			break;
+		}
+		case "clblast": {
+			cfg2.sources.push("whisper.cpp/ggml-opencl.cpp");
+			cfg2.defines.push("GGML_USE_CLBLAST");
+			cfg2.libraries.push("-lclblast");
+			if (import_node_os.default.platform() === "darwin") {
+				cfg2.libraries.push("-framework OpenCL");
+			} else {
+				cfg2.libraries.push("-lOpenCL");
+			}
+			break;
+		}
+		default: {
+		}
+	}
+	return cfg2;
+}
+function infer_backend() {
+	let backend = "cpu";
+	if (import_node_os.default.platform() === "darwin") {
+		backend = "accelerate";
+		if (import_node_os.default.arch() === "arm64") {
+			backend = "metal";
+		}
+	}
+	return backend;
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 &&
+	(module.exports = {
+		defines,
+		libraries,
+		sources,
+	});

--- a/package.json
+++ b/package.json
@@ -26,9 +26,8 @@
 	"scripts": {
 		"prepare": "husky install",
 		"format": "prettier --ignore-path .gitignore --write .",
-		"makelib": "cd whisper.cpp && make libwhisper.a",
 		"build": "tsup && node-gyp rebuild",
-		"install": "cd whisper.cpp && make libwhisper.a && cd .. && node-gyp rebuild",
+		"install": "node-gyp rebuild",
 		"changeset": "changeset",
 		"build:docs": "typedoc --out docs src/index.ts",
 		"test": "vitest --dir test"

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,0 +1,95 @@
+import os from "node:os";
+
+type ComputeBackend = "cpu" | "accelerate" | "metal" | "clblast" | "openblas";
+
+const cfg = config();
+
+export const sources = cfg.sources.join(" ");
+export const defines = cfg.defines.join(" ");
+export const libraries = cfg.libraries.join(" ");
+
+function config(): {
+	sources: string[];
+	defines: string[];
+	libraries: string[];
+} {
+	if (process.env.BYOL) {
+		return {
+			sources: [],
+			defines: [],
+			libraries: [process.env.BYOL],
+		};
+	}
+
+	const COMPUTE_BACKEND: ComputeBackend =
+		(process.env.COMPUTE_BACKEND as ComputeBackend | undefined) ?? infer_backend();
+
+	const cfg = {
+		sources: [
+			"whisper.cpp/whisper.cpp",
+			"whisper.cpp/ggml.c",
+			"whisper.cpp/ggml-alloc.c",
+			"whisper.cpp/ggml-backend.c",
+			"whisper.cpp/ggml-quants.c",
+		] as string[],
+		defines: [] as string[],
+		libraries: [] as string[],
+	};
+
+	switch (COMPUTE_BACKEND) {
+		case "accelerate": {
+			cfg.defines.push("GGML_USE_ACCELERATE");
+
+			cfg.libraries.push('"-framework Foundation"');
+			cfg.libraries.push('"-framework Accelerate"');
+			break;
+		}
+		case "metal": {
+			cfg.sources.push("whisper.cpp/ggml-metal.m");
+
+			cfg.defines.push("GGML_USE_ACCELERATE");
+			cfg.defines.push("GGML_USE_METAL");
+
+			cfg.libraries.push('"-framework Foundation"');
+			cfg.libraries.push('"-framework Accelerate"');
+			cfg.libraries.push('"-framework Metal"');
+			cfg.libraries.push('"-framework MetalKit"');
+			break;
+		}
+		case "openblas": {
+			cfg.defines.push("GGML_USE_OPENBLAS");
+
+			cfg.libraries.push("-lopenblas");
+			break;
+		}
+		case "clblast": {
+			cfg.sources.push("whisper.cpp/ggml-opencl.cpp");
+
+			cfg.defines.push("GGML_USE_CLBLAST");
+
+			cfg.libraries.push("-lclblast");
+			if (os.platform() === "darwin") {
+				cfg.libraries.push("-framework OpenCL");
+			} else {
+				cfg.libraries.push("-lOpenCL");
+			}
+			break;
+		}
+		default: {
+		}
+	}
+
+	return cfg;
+}
+
+function infer_backend(): ComputeBackend {
+	let backend: ComputeBackend = "cpu";
+	if (os.platform() === "darwin") {
+		backend = "accelerate";
+		if (os.arch() === "arm64") {
+			backend = "metal";
+		}
+	}
+
+	return backend;
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-	entry: ["src/index.ts"],
+	entry: ["src/index.ts", "src/build.ts"],
 	outDir: "dist",
 	dts: true,
 });


### PR DESCRIPTION
This PR moved all build process into gyp, no other commands are involved now. Which allows windows to use the package without setting up other build tools.

Also, a `BYOL` env var is supported during the building process, which allows users to use their own `libwhisper.a` or `libwhisper.so`, enabling other accelerations of whisper.cpp in different environment.

```sh
BYOL="/path/to/libwhisper.a" pnpm i smart-whisper
```