### PR TITLE
feat: allow to disable debug info in production

### DIFF
--- a/.changeset/hip-weeks-promise.md
+++ b/.changeset/hip-weeks-promise.md
@@ -1,0 +1,5 @@
+---
+"smart-whisper": minor
+---
+
+Allow to disable debug info in production


### PR DESCRIPTION
## Examples

In production:

```bash
% NODE_ENV=production ts-node examples/transcribe.ts whisper.cpp/models/ggml-medium.en.bin whisper.cpp/samples/jfk.wav

[
  {
    "from": 0,
    "to": 11000,
    "text": " And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country."
  }
]
```

Not in production:

```bash
% ts-node examples/transcribe.ts whisper.cpp/models/ggml-medium.en.bin whisper.cpp/samples/jfk.wav

% ts-node examples/transcribe.ts whisper.cpp/models/ggml-medium.en.bin whisper.cpp/samples/jfk.wav                    
whisper_init_from_file_with_params_no_state: loading model from 'whisper.cpp/models/ggml-medium.en.bin'
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51864
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 1024
whisper_model_load: n_audio_head  = 16
whisper_model_load: n_audio_layer = 24
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 1024
whisper_model_load: n_text_head   = 16
whisper_model_load: n_text_layer  = 24
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: qntvr         = 0
whisper_model_load: type          = 4 (medium)
whisper_model_load: adding 1607 extra tokens
whisper_model_load: n_langs       = 99
whisper_backend_init: using Metal backend
ggml_metal_init: allocating
ggml_metal_init: found device: Apple M1 Pro
ggml_metal_init: picking default device: Apple M1 Pro
ggml_metal_init: default.metallib not found, loading from source
ggml_metal_init: GGML_METAL_PATH_RESOURCES = ~/smart-whisper/whisper.cpp
ggml_metal_init: loading '~/smart-whisper/whisper.cpp/ggml-metal.metal'
ggml_metal_init: GPU name:   Apple M1 Pro
ggml_metal_init: GPU family: MTLGPUFamilyApple7  (1007)
ggml_metal_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_init: GPU family: MTLGPUFamilyMetal3  (5001)
ggml_metal_init: simdgroup reduction support   = true
ggml_metal_init: simdgroup matrix mul. support = true
ggml_metal_init: hasUnifiedMemory              = true
ggml_metal_init: recommendedMaxWorkingSetSize  = 11453.25 MB
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =  1023.20 MiB, ( 1024.83 / 10922.67)
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =   441.28 MiB, ( 1466.11 / 10922.67)
whisper_model_load:    Metal total size =  1533.52 MB (2 buffers)
whisper_model_load: model size    = 1533.14 MB

whisper_print_timings:     load time =   530.59 ms
whisper_print_timings:    total time =   530.70 ms
whisper_backend_init: using Metal backend
ggml_metal_init: allocating
ggml_metal_init: found device: Apple M1 Pro
ggml_metal_init: picking default device: Apple M1 Pro
ggml_metal_init: default.metallib not found, loading from source
ggml_metal_init: GGML_METAL_PATH_RESOURCES = ~/smart-whisper/whisper.cpp
ggml_metal_init: loading '~/smart-whisper/whisper.cpp/ggml-metal.metal'
ggml_metal_init: GPU name:   Apple M1 Pro
ggml_metal_init: GPU family: MTLGPUFamilyApple7  (1007)
ggml_metal_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_init: GPU family: MTLGPUFamilyMetal3  (5001)
ggml_metal_init: simdgroup reduction support   = true
ggml_metal_init: simdgroup matrix mul. support = true
ggml_metal_init: hasUnifiedMemory              = true
ggml_metal_init: recommendedMaxWorkingSetSize  = 11453.25 MB
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =   126.00 MiB, ( 1592.11 / 10922.67)
whisper_init_state: kv self size  =  132.12 MB
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =   140.62 MiB, ( 1732.73 / 10922.67)
whisper_init_state: kv cross size =  147.46 MB
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =     0.02 MiB, ( 1732.75 / 10922.67)
whisper_init_state: compute buffer (conv)   =   25.61 MB
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =     0.02 MiB, ( 1732.77 / 10922.67)
whisper_init_state: compute buffer (encode) =  170.28 MB
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =     0.02 MiB, ( 1732.78 / 10922.67)
whisper_init_state: compute buffer (cross)  =    7.85 MB
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =     0.02 MiB, ( 1732.80 / 10922.67)
whisper_init_state: compute buffer (decode) =   98.31 MB
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =    22.80 MiB, ( 1755.58 / 10922.67)
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =   160.78 MiB, ( 1916.34 / 10922.67)
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =     5.86 MiB, ( 1922.19 / 10922.67)
ggml_backend_metal_buffer_type_alloc_buffer: allocated buffer, size =    92.14 MiB, ( 2014.31 / 10922.67)
whisper_full_with_state: auto-detected language: hu (p = 0.010002)
ggml_metal_free: deallocating
[
  {
    "from": 0,
    "to": 11000,
    "text": " And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country."
  }
]
ggml_metal_free: deallocating
```